### PR TITLE
get_records accepts start & max parameters

### DIFF
--- a/lib/trackvia-api-sdk.rb
+++ b/lib/trackvia-api-sdk.rb
@@ -386,11 +386,11 @@ module Trackvia
 
     # Gets all accessible records accessible in the authorized view.
     #
-    def get_records(view_id)
+    def get_records(view_id, start = 0, max = 1000)
       begin
         url = "#{base_uri}/openapi/views/#{view_id}"
 
-        json = RestClient.get url, { :params => auth_params, :accept => :json }
+        json = RestClient.get url, { :params => auth_params.merge({'start' => start, 'max' => max}), :accept => :json }
         records = JSON.parse(json)
 
       rescue RestClient::Exception => e


### PR DESCRIPTION
get_records currently doesn't accept pagination parameters and thus will only return the first 1000 records. this method should accept start and max parameters to facilitate pagination and iterating through records. this PR addresses the issue descibed here - https://github.com/Trackvia/API-Ruby-SDK/issues/3