### PR TITLE
Backtrace breaks ruby contract and makes tests fails, renaming to sta…

### DIFF
--- a/lib/trackvia-api-sdk/exceptions.rb
+++ b/lib/trackvia-api-sdk/exceptions.rb
@@ -1,14 +1,14 @@
 module Trackvia
   class ApiError < StandardError
-    attr_reader :cause, :errors, :message, :name, :code, :backtrace, :error, :description
+    attr_reader :cause, :errors, :message, :name, :code, :stack_trace, :error, :description
 
-    def initialize(cause, errors, message, name, code, backtrace, error, description)
+    def initialize(cause, errors, message, name, code, stack_trace, error, description)
       @cause = cause
       @errors = errors
       @message = message
       @name = name
       @code = code
-      @backtrace = backtrace
+      @stack_trace = stack_trace
       @error = error
       @description = description
     end


### PR DESCRIPTION
…ck_trace

When we were attempting to run tests, we noticed that backtrace was nil'ing out rspec's ability to trace errors, thus we renamed ```backtrace``` to ```stack_trace``` to avoid conflicts with ruby.